### PR TITLE
Make nullable parameter explicit to handle deprecation of php 8.4

### DIFF
--- a/src/Console/BundleInitCommand.php
+++ b/src/Console/BundleInitCommand.php
@@ -18,7 +18,7 @@ class BundleInitCommand extends Command
 
     private KernelInterface $kernel;
 
-    public function __construct(KernelInterface $kernel, string $name = null)
+    public function __construct(KernelInterface $kernel, ?string $name = null)
     {
         parent::__construct($name);
         $this->kernel = $kernel;

--- a/src/Console/LogoutCommand.php
+++ b/src/Console/LogoutCommand.php
@@ -18,7 +18,7 @@ class LogoutCommand extends Command
 {
     private Nutgram $bot;
 
-    public function __construct(Nutgram $bot, string $name = null)
+    public function __construct(Nutgram $bot, ?string $name = null)
     {
         parent::__construct($name);
         $this->bot = $bot;

--- a/src/Console/RegisterCommandsCommand.php
+++ b/src/Console/RegisterCommandsCommand.php
@@ -18,7 +18,7 @@ class RegisterCommandsCommand extends Command
 
     private Nutgram $bot;
 
-    public function __construct(Nutgram $bot, string $name = null)
+    public function __construct(Nutgram $bot, ?string $name = null)
     {
         parent::__construct($name);
         $this->bot = $bot;

--- a/src/Console/RunCommand.php
+++ b/src/Console/RunCommand.php
@@ -17,7 +17,7 @@ class RunCommand extends Command
 
     private Nutgram $bot;
 
-    public function __construct(Nutgram $bot, string $name = null)
+    public function __construct(Nutgram $bot, ?string $name = null)
     {
         parent::__construct($name);
         $this->bot = $bot;

--- a/src/Console/WebhookInfoCommand.php
+++ b/src/Console/WebhookInfoCommand.php
@@ -18,7 +18,7 @@ class WebhookInfoCommand extends Command
 
     private Nutgram $bot;
 
-    public function __construct(Nutgram $bot, string $name = null)
+    public function __construct(Nutgram $bot, ?string $name = null)
     {
         parent::__construct($name);
         $this->bot = $bot;

--- a/src/Console/WebhookRemoveCommand.php
+++ b/src/Console/WebhookRemoveCommand.php
@@ -18,7 +18,7 @@ class WebhookRemoveCommand extends Command
 {
     private Nutgram $bot;
 
-    public function __construct(Nutgram $bot, string $name = null)
+    public function __construct(Nutgram $bot, ?string $name = null)
     {
         parent::__construct($name);
         $this->bot = $bot;

--- a/src/Console/WebhookSetCommand.php
+++ b/src/Console/WebhookSetCommand.php
@@ -19,7 +19,7 @@ class WebhookSetCommand extends Command
 {
     private Nutgram $bot;
 
-    public function __construct(Nutgram $bot, string $name = null)
+    public function __construct(Nutgram $bot, ?string $name = null)
     {
         parent::__construct($name);
         $this->bot = $bot;


### PR DESCRIPTION
* https://wiki.php.net/rfc/deprecate-implicitly-nullable-types