### PR TITLE
Fix safe mode not being safe

### DIFF
--- a/config/nutgram.yaml
+++ b/config/nutgram.yaml
@@ -2,8 +2,8 @@ nutgram:
   # The Telegram bot token
   token: '%env(string:TELEGRAM_TOKEN)%'
 
-  # If true, the webhook mode validates the incoming IP range is from a Telegram server
-  safeMode: false
+  # Specify webhook secret for increased security
+  #webhook_secret: '%env(string:TELEGRAM_TOKEN)%'
 
   # If the nutgram bundle should automatically load the routes from config/telegram.php
   routes: true

--- a/src/Console/BundleInitCommand.php
+++ b/src/Console/BundleInitCommand.php
@@ -18,7 +18,7 @@ class BundleInitCommand extends Command
 
     private KernelInterface $kernel;
 
-    public function __construct(KernelInterface $kernel, string $name = null)
+    public function __construct(KernelInterface $kernel, ?string $name = null)
     {
         parent::__construct($name);
         $this->kernel = $kernel;

--- a/src/Console/LogoutCommand.php
+++ b/src/Console/LogoutCommand.php
@@ -18,7 +18,7 @@ class LogoutCommand extends Command
 {
     private Nutgram $bot;
 
-    public function __construct(Nutgram $bot, string $name = null)
+    public function __construct(Nutgram $bot, ?string $name = null)
     {
         parent::__construct($name);
         $this->bot = $bot;

--- a/src/Console/RegisterCommandsCommand.php
+++ b/src/Console/RegisterCommandsCommand.php
@@ -18,7 +18,7 @@ class RegisterCommandsCommand extends Command
 
     private Nutgram $bot;
 
-    public function __construct(Nutgram $bot, string $name = null)
+    public function __construct(Nutgram $bot, ?string $name = null)
     {
         parent::__construct($name);
         $this->bot = $bot;

--- a/src/Console/RunCommand.php
+++ b/src/Console/RunCommand.php
@@ -17,7 +17,7 @@ class RunCommand extends Command
 
     private Nutgram $bot;
 
-    public function __construct(Nutgram $bot, string $name = null)
+    public function __construct(Nutgram $bot, ?string $name = null)
     {
         parent::__construct($name);
         $this->bot = $bot;

--- a/src/Console/WebhookInfoCommand.php
+++ b/src/Console/WebhookInfoCommand.php
@@ -18,7 +18,7 @@ class WebhookInfoCommand extends Command
 
     private Nutgram $bot;
 
-    public function __construct(Nutgram $bot, string $name = null)
+    public function __construct(Nutgram $bot, ?string $name = null)
     {
         parent::__construct($name);
         $this->bot = $bot;

--- a/src/Console/WebhookRemoveCommand.php
+++ b/src/Console/WebhookRemoveCommand.php
@@ -18,7 +18,7 @@ class WebhookRemoveCommand extends Command
 {
     private Nutgram $bot;
 
-    public function __construct(Nutgram $bot, string $name = null)
+    public function __construct(Nutgram $bot, ?string $name = null)
     {
         parent::__construct($name);
         $this->bot = $bot;

--- a/src/Console/WebhookSetCommand.php
+++ b/src/Console/WebhookSetCommand.php
@@ -22,7 +22,7 @@ class WebhookSetCommand extends Command
 
     private ParameterBagInterface $parameters;
 
-    public function __construct(Nutgram $bot, ParameterBagInterface $parameters, string $name = null)
+    public function __construct(Nutgram $bot, ParameterBagInterface $parameters, ?string $name = null)
     {
         parent::__construct($name);
         $this->bot = $bot;

--- a/src/Console/WebhookSetCommand.php
+++ b/src/Console/WebhookSetCommand.php
@@ -10,6 +10,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 
 #[AsCommand(
     name: 'nutgram:hook:set',
@@ -19,10 +20,13 @@ class WebhookSetCommand extends Command
 {
     private Nutgram $bot;
 
-    public function __construct(Nutgram $bot, string $name = null)
+    private ParameterBagInterface $parameters;
+
+    public function __construct(Nutgram $bot, ParameterBagInterface $parameters, string $name = null)
     {
         parent::__construct($name);
         $this->bot = $bot;
+        $this->parameters = $parameters;
     }
 
     protected function configure(): void
@@ -50,7 +54,8 @@ class WebhookSetCommand extends Command
             $max_connections = (int)$max_connections;
         }
 
-        $this->bot->setWebhook($url, ip_address: $ip_address, max_connections: $max_connections);
+        $secret = $this->parameters->get('nutgram.config')['webhook_secret'];
+        $this->bot->setWebhook($url, ip_address: $ip_address, max_connections: $max_connections, secret_token: $secret);
 
         $io->info("Bot webhook set with url: $url");
 

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -14,7 +14,7 @@ class Configuration implements ConfigurationInterface
         $treeBuilder->getRootNode()
             ->children()
                 ->scalarNode('token')->end()
-                ->booleanNode('safeMode')->end()
+				->scalarNode('webhook_secret')->defaultNull()->end()
                 ->booleanNode('routes')->end()
                 ->arrayNode('config')
                 ->children()

--- a/src/DependencyInjection/Factory/NutgramFactory.php
+++ b/src/DependencyInjection/Factory/NutgramFactory.php
@@ -53,8 +53,9 @@ class NutgramFactory
         } else {
             $webhook = Webhook::class;
 
-            if ($config['safe_mode'] ?? false) {
-                $webhook = new $webhook(fn() => $requestStack->getCurrentRequest()?->getClientIp());
+            if ($config['webhook_secret']) {
+                $webhook = new Webhook(secretToken: $config['webhook_secret']);
+                $webhook->setSafeMode(true);
             }
 
             $bot->setRunningMode($webhook);

--- a/tests/Fixtures/test_config.yaml
+++ b/tests/Fixtures/test_config.yaml
@@ -4,8 +4,8 @@ framework:
 
 nutgram:
   token: '%env(string:TELEGRAM_TOKEN)%'
-  safeMode: false
   routes: true
+  webhook_secret: 'VerySecret'
   config:
     botId: 123
     apiUrl: 'BlaBla'

--- a/tests/Functional/CommandTest.php
+++ b/tests/Functional/CommandTest.php
@@ -8,6 +8,7 @@ use SergiX44\NutgramBundle\Console\WebhookInfoCommand;
 use SergiX44\NutgramBundle\Console\WebhookRemoveCommand;
 use SergiX44\NutgramBundle\Console\WebhookSetCommand;
 use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 
 it('call the logout command', function () {
     /** @var \SergiX44\Nutgram\Testing\FakeNutgram $instance */
@@ -72,8 +73,9 @@ it('call the remove webhook', function () {
 it('calls the set webhook', function () {
     /** @var \SergiX44\Nutgram\Testing\FakeNutgram $instance */
     $instance = static::getContainer()->get(Nutgram::class);
+    $parameters = static::getContainer()->get(ParameterBagInterface::class);
 
-    $commandTester = new CommandTester(new WebhookSetCommand($instance));
+    $commandTester = new CommandTester(new WebhookSetCommand($instance, $parameters));
     $commandTester->execute(['url' => 'http://foo.bar']);
     $commandTester->assertCommandIsSuccessful();
 


### PR DESCRIPTION
**Fix safe mode being weird:**

Safe mode was specified in the bundle documentation to check if a request came from Telegram IP address which wasn't the case.

```yaml
# If true, the webhook mode validates the incoming IP range is from a Telegram server
safeMode: false
```

Therefore I removed this setting and the following piece of code:

```php
if ($config['safe_mode'] ?? false) {
    $webhook = new $webhook(fn() => $requestStack->getCurrentRequest()?->getClientIp());
}
``` 

**Make safe mode actually safe:**

I reworked this in the following way.

- Add a new configuration option: `webhook_secret`
  By default the option is commented out. You can uncomment it and specify a secret.
- Modify the [*setWebbok* command](https://github.com/alwaeles/nutgram-symfony/blob/master/src/Console/WebhookSetCommand.php) to consume the secret.
- Modify [NutgramFactory](https://github.com/alwaeles/nutgram-symfony/blob/master/src/DependencyInjection/Factory/NutgramFactory.php) to consume the secret.

This PR also fixes the following issue: nutgram/nutgram#793