### PR TITLE
Add void as return type (deprecation php8.4)

### DIFF
--- a/src/DependencyInjection/NutgramExtension.php
+++ b/src/DependencyInjection/NutgramExtension.php
@@ -9,7 +9,7 @@ use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
 
 class NutgramExtension extends Extension
 {
-    public function load(array $configs, ContainerBuilder $container)
+    public function load(array $configs, ContainerBuilder $container): void
     {
         $configuration = new Configuration();
 


### PR DESCRIPTION
Deprecation message:

Method
"Symfony\Component\DependencyInjection\Extension\ExtensionInterface::load()" might add "void" as a native return type declaration in the future. Do the same in implementation "SergiX44\NutgramBundle\DependencyInjection\NutgramExtension" now to avoid errors or add an explicit @return annotation to suppress this message.